### PR TITLE
correct typo in transferOldData method

### DIFF
--- a/src/main/java/io/github/thatsmusic99/headsplus/sql/StatisticsSQLManager.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/sql/StatisticsSQLManager.java
@@ -88,7 +88,7 @@ public class StatisticsSQLManager extends SQLManager {
                         if (defaultSection != null && defaultSection.getKeys(false).size() != 0) {
                             head = defaultSection.getKeys(false).get(0);
                         }
-                        int total = Integer.parseInt(String.valueOf(huntingObj.get(mobObj)));
+                        int total = Integer.parseInt(String.valueOf(craftingObj.get(mobObj)));
                         addToTotalSync(uuid, CollectionType.CRAFTING, head, "mob=" + mobObj, total);
                     }
                 }


### PR DESCRIPTION
I was getting an exception when updating from v6 to 7.0.1 - looks like a copy/paste typo.