### PR TITLE
HeadCraftEvent is not firing

### DIFF
--- a/src/main/java/io/github/thatsmusic99/headsplus/config/ConfigCrafting.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/config/ConfigCrafting.java
@@ -111,6 +111,10 @@ public class ConfigCrafting extends FeatureConfig {
         return getDouble(key + ".price", getDouble("base-item.price"));
     }
 
+    public long getCraftingXp(String key) {
+        return getLong(key + ".xp", MainConfig.get().getCraftingHeads().DEFAULT_CRAFTING_XP);
+    }
+
     public String getDisplayName(String key) {
         return MessagesManager.get().formatMsg(getString(key + ".display-name", getString("base-item.display-name")), null)
                 .replaceAll("\\{type}", getString(key + ".display-type", getString("base-item.display-type")));

--- a/src/main/java/io/github/thatsmusic99/headsplus/config/MainConfig.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/config/MainConfig.java
@@ -21,6 +21,7 @@ public class MainConfig extends HPConfig {
     private MobDrops mobDrops;
     private PlayerDrops playerDrops;
     private SellingHeads sellingHeads;
+    private CraftingHeads craftingHeads;
     private Masks masks;
     private Autograbber autograbber;
     private Challenges challenges;
@@ -181,6 +182,9 @@ public class MainConfig extends HPConfig {
                 "that.");
         addDefault("use-sellhead-gui", true, "Whether or not the sellhead GUI is opened when a player does /sellhead.");
         addDefault("case-sensitive-names", false, "Whether or not names in /sellhead should be case sensitive.");
+
+        addSection("Crafting Heads");
+        addDefault("default-crafting-xp", 10, "The default amount of XP (plugin) gained when crafting a head.\n");
 
         addSection("Masks");
         addDefault("check-interval", 60, "How often in ticks the plugin checks to make sure it is still on the " +
@@ -424,6 +428,7 @@ public class MainConfig extends HPConfig {
         mobDrops = new MobDrops();
         playerDrops = new PlayerDrops();
         sellingHeads = new SellingHeads();
+        craftingHeads = new CraftingHeads();
         masks = new Masks();
         autograbber = new Autograbber();
         challenges = new Challenges();
@@ -475,6 +480,10 @@ public class MainConfig extends HPConfig {
 
     public SellingHeads getSellingHeads() {
         return sellingHeads;
+    }
+
+    public CraftingHeads getCraftingHeads() {
+        return craftingHeads;
     }
 
     public MobDrops getMobDrops() {
@@ -579,6 +588,10 @@ public class MainConfig extends HPConfig {
         public final boolean STOP_PLACEMENT = getBoolean("stop-placement-of-sellable-heads");
         public final boolean USE_GUI = getBoolean("use-sellhead-gui");
         public final boolean CASE_INSENSITIVE = getBoolean("case-sensitive-names");
+    }
+
+    public class CraftingHeads {
+        public final long DEFAULT_CRAFTING_XP = getLong("default-crafting-xp");
     }
 
     public class Masks {

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/EntityDeathListener.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/EntityDeathListener.java
@@ -37,7 +37,7 @@ public class EntityDeathListener extends HeadsPlusListener<EntityDeathEvent> {
         // I SWEAR TO GOD WORLDGUARD IS SUCH A BRAT
         if (!addData("not-wg-restricted",
                 !HeadsPlus.get().canUseWG() || FlagHandler.canDrop(event.getEntity().getLocation(),
-                        event.getEntity().getType())))
+                        event.getEntity().getType().toString())))
             return;
 
         if (!shouldDropHead(event.getEntity())) return;

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/LeaderboardListeners.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/LeaderboardListeners.java
@@ -6,6 +6,7 @@ import io.github.thatsmusic99.headsplus.api.HPPlayer;
 import io.github.thatsmusic99.headsplus.api.events.EntityHeadDropEvent;
 import io.github.thatsmusic99.headsplus.api.events.HeadCraftEvent;
 import io.github.thatsmusic99.headsplus.api.events.PlayerHeadDropEvent;
+import io.github.thatsmusic99.headsplus.config.ConfigCrafting;
 import io.github.thatsmusic99.headsplus.config.MainConfig;
 import io.github.thatsmusic99.headsplus.managers.RestrictionsManager;
 import io.github.thatsmusic99.headsplus.sql.StatisticsSQLManager;
@@ -109,7 +110,8 @@ public class LeaderboardListeners implements Listener {
         public void onEvent(HeadCraftEvent event) {
             Player player = event.getPlayer();
             if (RestrictionsManager.canUse(player.getWorld().getName(), RestrictionsManager.ActionType.XP_GAINS)) {
-                HPPlayer.getHPPlayer(player.getUniqueId()).addXp(MainConfig.get().getCraftingHeads().DEFAULT_CRAFTING_XP * event.getHeadsCrafted());
+                String key = "recipes." + event.getType().substring(event.getType().indexOf("_") + 1);
+                HPPlayer.getHPPlayer(player.getUniqueId()).addXp(ConfigCrafting.get().getCraftingXp(key) * event.getHeadsCrafted());
             }
             if (!MainConfig.get().getMainFeatures().LEADERBOARDS || event.getType() == null) return;
             if (event.getType().equalsIgnoreCase("invalid") || event.getType().isEmpty()) return;

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/LeaderboardListeners.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/LeaderboardListeners.java
@@ -109,7 +109,7 @@ public class LeaderboardListeners implements Listener {
         public void onEvent(HeadCraftEvent event) {
             Player player = event.getPlayer();
             if (RestrictionsManager.canUse(player.getWorld().getName(), RestrictionsManager.ActionType.XP_GAINS)) {
-                //HPPlayer.getHPPlayer(player.getUniqueId()).addXp(0 * event.getHeadsCrafted());
+                HPPlayer.getHPPlayer(player.getUniqueId()).addXp(MainConfig.get().getCraftingHeads().DEFAULT_CRAFTING_XP * event.getHeadsCrafted());
             }
             if (!MainConfig.get().getMainFeatures().LEADERBOARDS || event.getType() == null) return;
             if (event.getType().equalsIgnoreCase("invalid") || event.getType().isEmpty()) return;

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerCraftListener.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerCraftListener.java
@@ -12,11 +12,13 @@ import io.github.thatsmusic99.headsplus.util.events.HeadsPlusListener;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 
 public class PlayerCraftListener extends HeadsPlusListener<InventoryClickEvent> {
@@ -71,8 +73,16 @@ public class PlayerCraftListener extends HeadsPlusListener<InventoryClickEvent> 
 
     private int shift(InventoryClickEvent e) {
         if (!e.isShiftClick()) return 1;
-        int slot = getSlot(e.getInventory().getType());
-        return e.getInventory().getItem(slot).getAmount();
+        ItemStack[] itemStacks = e.getInventory().getStorageContents();
+
+        int amount = Integer.MAX_VALUE;
+        for (ItemStack is : itemStacks) {
+            if (is == null || is.getAmount() == 0 || is.getType() == Material.PLAYER_HEAD) {
+                continue;
+            }
+            amount = Math.min(amount, is.getAmount());
+        }
+        return amount;
     }
 
     private void fireEvent(InventoryClickEvent e) {

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerCraftListener.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerCraftListener.java
@@ -10,6 +10,7 @@ import io.github.thatsmusic99.headsplus.util.FlagHandler;
 import io.github.thatsmusic99.headsplus.util.events.HeadsPlusEventExecutor;
 import io.github.thatsmusic99.headsplus.util.events.HeadsPlusListener;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -40,8 +41,15 @@ public class PlayerCraftListener extends HeadsPlusListener<InventoryClickEvent> 
         if (e.getCurrentItem() == null) return;
         if (!isCorrectSlot(e)) return;
         if (!(e.getCurrentItem().getItemMeta() instanceof SkullMeta)) return;
+
+        if (e.getClass().getSimpleName().equals("CraftItemEvent")) {
+            String name = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', e.getCurrentItem().getItemMeta().getDisplayName()));
+            PersistenceManager.get().setSellType(e.getCurrentItem(), name.toUpperCase().replaceAll("[^A-Z]", ""));
+        }
+
         String type = PersistenceManager.get().getSellType(e.getCurrentItem());
         if (type == null || type.isEmpty()) return;
+
         if (!player.hasPermission("headsplus.craft")
                 || !RestrictionsManager.canUse(e.getWhoClicked().getWorld().getName(),
                 RestrictionsManager.ActionType.CRAFTING)) {
@@ -73,6 +81,7 @@ public class PlayerCraftListener extends HeadsPlusListener<InventoryClickEvent> 
         String type = PersistenceManager.get().getSellType(e.getCurrentItem());
         event = new HeadCraftEvent((Player) e.getWhoClicked(), e.getCurrentItem(), e.getWhoClicked().getWorld(),
                 e.getWhoClicked().getLocation(), amount, type);
+
         Bukkit.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             e.setCancelled(true);

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerCraftListener.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerCraftListener.java
@@ -10,10 +10,8 @@ import io.github.thatsmusic99.headsplus.util.FlagHandler;
 import io.github.thatsmusic99.headsplus.util.events.HeadsPlusEventExecutor;
 import io.github.thatsmusic99.headsplus.util.events.HeadsPlusListener;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -44,11 +42,6 @@ public class PlayerCraftListener extends HeadsPlusListener<InventoryClickEvent> 
         if (!isCorrectSlot(e)) return;
         if (!(e.getCurrentItem().getItemMeta() instanceof SkullMeta)) return;
 
-        if (e.getClass().getSimpleName().equals("CraftItemEvent")) {
-            String name = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', e.getCurrentItem().getItemMeta().getDisplayName()));
-            PersistenceManager.get().setSellType(e.getCurrentItem(), name.toUpperCase().replaceAll("[^A-Z]", ""));
-        }
-
         String type = PersistenceManager.get().getSellType(e.getCurrentItem());
         if (type == null || type.isEmpty()) return;
 
@@ -61,7 +54,8 @@ public class PlayerCraftListener extends HeadsPlusListener<InventoryClickEvent> 
         }
 
         if (HeadsPlus.get().canUseWG()) {
-            if (!FlagHandler.canCraft(e.getWhoClicked().getLocation(), EntityType.valueOf(type))) {
+            String name = type.substring(type.indexOf("_") + 1).toUpperCase();
+            if (!FlagHandler.canCraft(e.getWhoClicked().getLocation(), name)) {
                 MessagesManager.get().sendMessage("event.cannot-craft-heads-here", e.getWhoClicked());
                 e.setCancelled(true);
                 return;

--- a/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerDeathListener.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/listeners/PlayerDeathListener.java
@@ -53,7 +53,7 @@ public class PlayerDeathListener extends HeadsPlusListener<PlayerDeathEvent> {
         // Make sure the entity isn't from MythicMobs
         if (addData("is-mythic-mob", HPUtils.isMythicMob(event.getEntity()))) return;
         if (!addData("not-wg-restricted", Bukkit.getPluginManager().getPlugin("WorldGuard") == null
-                || FlagHandler.canDrop(event.getEntity().getLocation(), event.getEntity().getType()))) return;
+                || FlagHandler.canDrop(event.getEntity().getLocation(), event.getEntity().getType().toString()))) return;
         if (!shouldDropHead(event.getEntity())) return;
         double fixedChance = addData("fixed-chance", ConfigMobs.get().getPlayerChance(victim.getName()));
         if (fixedChance == 0) return;

--- a/src/main/java/io/github/thatsmusic99/headsplus/managers/CraftingManager.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/managers/CraftingManager.java
@@ -101,6 +101,7 @@ public class CraftingManager {
         //
         Recipe recipe;
         NamespacedKey namespacedKey = new NamespacedKey(HeadsPlus.get(), "crafting_" + key);
+        PersistenceManager.get().setSellType(item, namespacedKey.toString());
         switch (recipeType) {
             case FURNACE:
                 recipe = new FurnaceRecipe(namespacedKey, item, choices.get(0), section.getFloat("experience", 0.1f),

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/FlagHandler.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/FlagHandler.java
@@ -14,7 +14,6 @@ import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 import io.github.thatsmusic99.headsplus.HeadsPlus;
 import org.bukkit.Location;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
 import java.util.Set;
@@ -49,12 +48,12 @@ public class FlagHandler {
         return handler != null && HeadsPlus.get().canUseWG();
     }
 
-    public static boolean canDrop(Location location, EntityType type) {
+    public static boolean canDrop(Location location, String type) {
         if (!isHandling()) return true;
         return query(location, type, getHandler().HEAD_DROP);
     }
 
-    public static boolean canCraft(Location location, EntityType type) {
+    public static boolean canCraft(Location location, String type) {
         if (!isHandling()) return true;
         return query(location, type, getHandler().HEAD_CRAFT);
     }
@@ -74,7 +73,7 @@ public class FlagHandler {
         return regions.testState(wrappedPlayer, getHandler().ALLOW_MASKS);
     }
 
-    private static boolean query(Location location, EntityType type, StateFlag flag) {
+    private static boolean query(Location location, String type, StateFlag flag) {
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         // Get the region manager for the world we're inWorld
         RegionManager manager = container.get(BukkitAdapter.adapt(location.getWorld()));
@@ -87,11 +86,11 @@ public class FlagHandler {
         if (regions.testState(null, flag)) {
             Set<String> allowedMobs = regions.queryValue(null, getHandler().HEAD_ALLOWED_IDS);
             if (allowedMobs != null && !allowedMobs.isEmpty()) {
-                return allowedMobs.contains(type.name());
+                return allowedMobs.contains(type);
             }
             Set<String> deniedMobs = regions.queryValue(null, getHandler().HEAD_DENIED_IDS);
             if (deniedMobs != null && !deniedMobs.isEmpty()) {
-                return !deniedMobs.contains(type.name());
+                return !deniedMobs.contains(type);
             }
             return true;
         }


### PR DESCRIPTION
Hi, I noticed that the `HeadCraftEvent` was not firing in v7.0.5, so had a look and found a possible fix for it. Also some issues with xp on crafting heads.

1) on crafting a head the `HeadCraftEvent` is never firing because `PlayerCraftListener` is exiting as `PersistenceManager.get().getSellType(e.getCurrentItem())` will return null/empty on a newly created head.

Checking for `CraftItemEvent` will allow the persistence data to be added, and the `HeadCraftEvent` will then fire correctly.

2) fixes the method for returning the number of craftable heads when shift-clicking the output slot of the crafting table.

3) restore the xp reward for crafting heads by adding a default to the config and calculating the xp based on number of heads crafted. 
This may help with #63 - not sure if there were other issues with crafting xp that I'm unaware of.
