### PR TITLE
reset level to zero when resetting xp

### DIFF
--- a/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
@@ -98,6 +98,10 @@ public class HPPlayer {
         this.xp = xp;
 
         if (MainConfig.get().getMainFeatures().LEVELS) {
+            if (xp == 0) {
+                resetLevel();
+                return;
+            }
             new BukkitRunnable() {
                 @Override
                 public void run() {
@@ -136,6 +140,12 @@ public class HPPlayer {
             }
         }
         PlayerSQLManager.get().setLevel(this.uuid, nextLevel.getConfigName());
+    }
+
+    private void resetLevel() {
+        PlayerSQLManager.get().setLevel(this.uuid, LevelsManager.get().getLevel(0).getConfigName());
+        level = 0;
+        nextLevel = 1;
     }
 
     public boolean hasHeadFavourited(String s) {

--- a/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
@@ -5,6 +5,7 @@ import io.github.thatsmusic99.headsplus.api.HPPlayer;
 import io.github.thatsmusic99.headsplus.commands.CommandInfo;
 import io.github.thatsmusic99.headsplus.commands.IHeadsPlusCommand;
 import io.github.thatsmusic99.headsplus.config.MessagesManager;
+import io.github.thatsmusic99.headsplus.managers.LevelsManager;
 import io.github.thatsmusic99.headsplus.config.MainConfig;
 import io.github.thatsmusic99.headsplus.sql.PlayerSQLManager;
 import io.github.thatsmusic99.headsplus.util.HPUtils;
@@ -99,7 +100,9 @@ public class XPCommand implements IHeadsPlusCommand {
                         return true;
                     }
                     PlayerSQLManager.get().setXP(args[1], 0);
+                    PlayerSQLManager.get().setLevel(args[1], LevelsManager.get().getLevel(0).getConfigName());
                     MessagesManager.get().sendMessage("commands.xp.reset-xp", sender, "{player}", args[1]);
+                    return true;
                 } else {
                     MessagesManager.get().sendMessage("commands.errors.no-perm", sender);
                 }

--- a/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
@@ -100,7 +100,9 @@ public class XPCommand implements IHeadsPlusCommand {
                         return true;
                     }
                     PlayerSQLManager.get().setXP(args[1], 0);
-                    PlayerSQLManager.get().setLevel(args[1], LevelsManager.get().getLevel(0).getConfigName());
+                    if (MainConfig.get().getMainFeatures().LEVELS && LevelsManager.get().getLevel(0) != null) {
+                        PlayerSQLManager.get().setLevel(args[1], LevelsManager.get().getLevel(0).getConfigName());
+                    }
                     MessagesManager.get().sendMessage("commands.xp.reset-xp", sender, "{player}", args[1]);
                     return true;
                 } else {

--- a/src/main/java/io/github/thatsmusic99/headsplus/sql/PlayerSQLManager.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/sql/PlayerSQLManager.java
@@ -223,6 +223,19 @@ public class PlayerSQLManager extends SQLManager {
         }, true, "set level " + level + " for " + uuid.toString());
     }
 
+    public CompletableFuture<Void> setLevel(String username, String level) {
+        return createConnection(connection -> {
+            int actualLevel = LevelsManager.get().getLevels().indexOf(level);
+            PreparedStatement statement = connection.prepareStatement("UPDATE headsplus_players SET level = ? " +
+                    "WHERE username = ?");
+            statement.setInt(1, actualLevel);
+            statement.setString(2, username);
+
+            statement.executeUpdate();
+            return null;
+        }, true, "set level " + level + " for " + username);
+    }
+
     private CompletableFuture<Void> updateJoinTimestamp(UUID uuid, long timestamp) {
         return createConnection(connection -> {
             PreparedStatement statement = connection.prepareStatement("UPDATE headsplus_players SET last_joined =" +


### PR DESCRIPTION
Currently when a player's xp is reset to zero, the player's level is not changed. This causes issues calculating the xp required to level up and the bossbar progress doesn't display properly which can result in multiple bars staying on screen.

So, when resetting a player's xp to zero. the player's level is now also reset.

Added method to set the level for an offline player.

Return true when resetting offline player's xp to avoid displaying usage message.
