### PR TITLE
Adding xp to a player is not always setting the correct level

### DIFF
--- a/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
@@ -112,7 +112,7 @@ public class HPPlayer {
                         jumps++;
                         Level level = nextLevelLocal;
                         nextLevelLocal = LevelsManager.get().getNextLevel(nextLevelLocal.getConfigName());
-                        if (MainConfig.get().getLevels().MULTIPLE_LEVEL_UPS) initLevelUp(jumps);
+                        if (MainConfig.get().getLevels().MULTIPLE_LEVEL_UPS) initLevelUp(1);
                         if (level.isrEnabled()) level.getReward().rewardPlayer(null, (Player) getPlayer());
                     }
                     if (!MainConfig.get().getLevels().MULTIPLE_LEVEL_UPS && jumps > 0) initLevelUp(jumps);

--- a/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
@@ -116,6 +116,7 @@ public class HPPlayer {
                         if (level.isrEnabled()) level.getReward().rewardPlayer(null, (Player) getPlayer());
                     }
                     if (!MainConfig.get().getLevels().MULTIPLE_LEVEL_UPS && jumps > 0) initLevelUp(jumps);
+                    PlayerSQLManager.get().setLevel(uuid, LevelsManager.get().getLevel(level).getConfigName());
 
                     HPUtils.addBossBar(getPlayer());
                 }
@@ -139,7 +140,6 @@ public class HPPlayer {
                         ChatColor.translateAlternateColorCodes('&', nextLevel.getDisplayName()));
             }
         }
-        PlayerSQLManager.get().setLevel(this.uuid, nextLevel.getConfigName());
     }
 
     private void resetLevel() {

--- a/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/api/HPPlayer.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public class HPPlayer {
 
@@ -35,10 +34,10 @@ public class HPPlayer {
     private final List<String> completeChallenges;
 
     public HPPlayer(UUID uuid) {
-        pinnedChallenges = HPUtils.ifNull(getValue(PinnedChallengeManager.get().getPinnedChallenges(uuid), "pinned challenges"), new ArrayList<>());
-        favouriteHeads = HPUtils.ifNull(getValue(FavouriteHeadsSQLManager.get().getFavouriteHeads(uuid), "favourite heads"), new ArrayList<>());
-        completeChallenges = HPUtils.ifNull(getValue(ChallengeSQLManager.get().getCompleteChallenges(uuid), "complete challenges"), new ArrayList<>());
-        level = HPUtils.ifNull(getValue(PlayerSQLManager.get().getLevel(uuid, false), "level"), 0);
+        pinnedChallenges = HPUtils.ifNull(HPUtils.getValue(PinnedChallengeManager.get().getPinnedChallenges(uuid), "pinned challenges"), new ArrayList<>());
+        favouriteHeads = HPUtils.ifNull(HPUtils.getValue(FavouriteHeadsSQLManager.get().getFavouriteHeads(uuid), "favourite heads"), new ArrayList<>());
+        completeChallenges = HPUtils.ifNull(HPUtils.getValue(ChallengeSQLManager.get().getCompleteChallenges(uuid), "complete challenges"), new ArrayList<>());
+        level = HPUtils.ifNull(HPUtils.getValue(PlayerSQLManager.get().getLevel(uuid, false), "level"), 0);
         int max = LevelsManager.get().getLevels().size();
         if (level > -1 && level + 1 < max) {
             this.nextLevel = level + 1;
@@ -46,7 +45,7 @@ public class HPPlayer {
         PlayerSQLManager.get().getLocale(uuid).thenAccept(result ->
                 result.ifPresent(str ->
                         MessagesManager.get().setPlayerLocale((Player) getPlayer(), str)));
-        xp = HPUtils.ifNull(getValue(PlayerSQLManager.get().getXP(uuid, true), "XP"), (long) 0);
+        xp = HPUtils.ifNull(HPUtils.getValue(PlayerSQLManager.get().getXP(uuid, true), "XP"), (long) 0);
         this.uuid = uuid;
         players.put(uuid, this);
     }
@@ -191,21 +190,5 @@ public class HPPlayer {
 
     public static void removePlayer(UUID uuid) {
         players.remove(uuid);
-    }
-
-    private <T> T getValue(CompletableFuture<T> task, String object) {
-        try {
-            return task.get();
-        } catch (InterruptedException e) {
-            HeadsPlus.get().getLogger().severe("Failed to get data for " + object + ": interrupted thread. Please try" +
-                    " again or restart the server. If none of the above works, please consult the necessary support" +
-                    " services (e.g. hosting)..");
-            e.printStackTrace();
-        } catch (ExecutionException e) {
-            HeadsPlus.get().getLogger().severe("Failed to get data for " + object + ": execution failed, " +
-                    "an internal error occurred. Please send the console error to the developer.");
-            e.printStackTrace();
-        }
-        return null;
     }
 }

--- a/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
@@ -29,7 +29,6 @@ import java.util.List;
 )
 public class XPCommand implements IHeadsPlusCommand {
 
-    private long updatedXp;
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
                              String[] args) {
@@ -60,7 +59,7 @@ public class XPCommand implements IHeadsPlusCommand {
                 }
 
                 PlayerSQLManager.get().addXP(args[1], amount).thenAcceptAsync(rood -> {
-                    updatedXp = HPUtils.ifNull(HPUtils.getValue(PlayerSQLManager.get().getXP(args[1], true), "XP"), (long) 0);
+                    long updatedXp = HPUtils.ifNull(HPUtils.getValue(PlayerSQLManager.get().getXP(args[1], true), "XP"), (long) 0);
 
                     MessagesManager.get().sendMessage("commands.xp.added-xp", sender, "{player}", args[1], "{xp}",
                             String.valueOf(updatedXp), "{amount}", args[3]);

--- a/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
@@ -65,7 +65,7 @@ public class XPCommand implements IHeadsPlusCommand {
                     MessagesManager.get().sendMessage("commands.xp.added-xp", sender, "{player}", args[1], "{xp}",
                             String.valueOf(updatedXp), "{amount}", args[3]);
 
-                    if (MainConfig.get().getMainFeatures().LEVELS) {
+                    if (MainConfig.get().getMainFeatures().LEVELS && LevelsManager.get().getLevels().size() > 0) {
                         PlayerSQLManager.get().setLevel(args[1], LevelsManager.get().getLevelFromXp(updatedXp).getConfigName());
                     }
                 }, HeadsPlus.async);

--- a/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/commands/maincommand/XPCommand.java
@@ -29,6 +29,7 @@ import java.util.List;
 )
 public class XPCommand implements IHeadsPlusCommand {
 
+    private long updatedXp;
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
                              String[] args) {
@@ -57,10 +58,18 @@ public class XPCommand implements IHeadsPlusCommand {
                             String.valueOf(player.getXp()), "{amount}", args[3]);
                     return true;
                 }
-                PlayerSQLManager.get().addXP(args[1], amount).thenAcceptAsync(rood ->
-                        MessagesManager.get().sendMessage("commands.xp.added-xp", sender, "{player}", args[1], "{xp}",
-                                String.valueOf(PlayerSQLManager.get().getXP(args[1], false)), "{amount}", args[3]),
-                        HeadsPlus.async);
+
+                PlayerSQLManager.get().addXP(args[1], amount).thenAcceptAsync(rood -> {
+                    updatedXp = HPUtils.ifNull(HPUtils.getValue(PlayerSQLManager.get().getXP(args[1], true), "XP"), (long) 0);
+
+                    MessagesManager.get().sendMessage("commands.xp.added-xp", sender, "{player}", args[1], "{xp}",
+                            String.valueOf(updatedXp), "{amount}", args[3]);
+
+                    if (MainConfig.get().getMainFeatures().LEVELS) {
+                        PlayerSQLManager.get().setLevel(args[1], LevelsManager.get().getLevelFromXp(updatedXp).getConfigName());
+                    }
+                }, HeadsPlus.async);
+
                 return true;
             case "subtract":
                 if (!sender.hasPermission("headsplus.maincommand.xp.subtract")) {

--- a/src/main/java/io/github/thatsmusic99/headsplus/managers/LevelsManager.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/managers/LevelsManager.java
@@ -48,6 +48,18 @@ public class LevelsManager {
         return getLevel(order);
     }
 
+    public Level getLevelFromXp(long xp) {
+        int index = 0;
+        for (String name : levelOrder) {
+            if (levels.get(name).getRequiredXP() <= xp) {
+                continue;
+            }
+            index = levelOrder.indexOf(name);
+            break;
+        }
+        return index > 0 ? getLevel(index - 1) : getLevel(0);
+    }
+
     public List<String> getLevels() {
         return levelOrder;
     }

--- a/src/main/java/io/github/thatsmusic99/headsplus/util/HPUtils.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/util/HPUtils.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 
@@ -157,6 +158,22 @@ public class HPUtils {
     public static CompletableFuture<OfflinePlayer> getOfflinePlayer(String name) {
         return CompletableFuture.supplyAsync(() -> Bukkit.getOfflinePlayer(name), HeadsPlus.async)
                 .thenApplyAsync(player -> player, HeadsPlus.sync);
+    }
+
+    public static <T> T getValue(CompletableFuture<T> task, String object) {
+        try {
+            return task.get();
+        } catch (InterruptedException e) {
+            HeadsPlus.get().getLogger().severe("Failed to get data for " + object + ": interrupted thread. Please try" +
+                    " again or restart the server. If none of the above works, please consult the necessary support" +
+                    " services (e.g. hosting)..");
+            e.printStackTrace();
+        } catch (ExecutionException e) {
+            HeadsPlus.get().getLogger().severe("Failed to get data for " + object + ": execution failed, " +
+                    "an internal error occurred. Please send the console error to the developer.");
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public static class PlaceholderInfo {


### PR DESCRIPTION
1) When adding xp to an _online_ player, if MULTIPLE_LEVEL_UPS is enabled levels can be 'skipped' because the levels are incremented too quickly - see picture 1.

![HP jumping levels](https://user-images.githubusercontent.com/6975392/164192719-393e6305-4865-4d2f-933a-4f351c88c078.PNG)

Suggested fix:  the initLevelUp method should have an argument of 1 each time its called (not the value of 'jumps') so that levels are obtained sequentially. See picture 2.

![HP FIXED jumping levels](https://user-images.githubusercontent.com/6975392/164192871-c5478875-1ccc-40e5-9b2d-ce08b4956813.PNG)

====

2) If MULTIPLE_LEVEL_UPS is enabled, the database is updated on each 'level-up' iteration. When there are multiple iterations, these async tasks will finish in a random order, and the final database update doesn't necessarily set the highest level.

Suggested fix: update the database once on the final iteration.

====

3) When adding xp to an _offline_ player, the xp is set correctly but the message displayed is not evaluated correctly, and any new level is not calculated or set - see picture 3.

![HP add to offline player](https://user-images.githubusercontent.com/6975392/164193229-e45aacdb-4a85-4487-b43a-caa5793067d9.PNG)


Suggested fix:  move the method for getting the value returned by the completablefuture task to HPUtils, and use this method to correctly display the xp update message for an offline player.

Set the correct level when adding xp to an offline player.