### PR TITLE
fix inventory size check when cancelling inventory item move

### DIFF
--- a/src/main/java/io/github/thatsmusic99/headsplus/inventories/BaseInventory.java
+++ b/src/main/java/io/github/thatsmusic99/headsplus/inventories/BaseInventory.java
@@ -188,7 +188,7 @@ public abstract class BaseInventory implements InventoryHolder, Listener {
                     player.getInventory().setItem(i, new ItemStack(Material.AIR));
                 }
             }
-            if (slot > inventory.getSize()) return;
+            if (slot > inventory.getSize() -1) return;
             IconClickEvent iconEvent = new IconClickEvent(player, icons[slot]);
             Bukkit.getPluginManager().callEvent(iconEvent);
             if (!iconEvent.isCancelled()) {


### PR DESCRIPTION
Attempting to move the item in the first slot of the bottom inventory causes an exception:
 ```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 54 out of bounds for length 54
	at io.github.thatsmusic99.headsplus.inventories.BaseInventory.onInventoryClick(BaseInventory.java:192) ~[?:?]
```
This is using HP 7.0.7 on Spigot 1.19.